### PR TITLE
Task/tao 4692 migrate to libsass

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -23,9 +23,9 @@ return array(
     'label' => 'xmlEditRp',
     'description' => 'xml editing and debugging tools',
     'license' => 'GPL-2.0',
-    'version' => '1.0.0',
-	'author' => 'Open Assessment Technologies SA',
-	'requires' => array(
+    'version' => '1.0.1',
+    'author' => 'Open Assessment Technologies SA',
+    'requires' => array(
         'xmlEdit' => '>=1.1.0',
         'taoQtiItem' => '>=2.27.0'
     ),

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -38,14 +38,12 @@ class Updater extends common_ext_ExtensionUpdater
     {
         $this->setVersion($initialVersion);
 
-        if($this->isVersion('0.1.0')){
+        if ($this->isVersion('0.1.0')) {
             $registry = QtiCreatorClientConfigRegistry::getRegistry();
             $registry->registerPlugin('xmlResponseProcessing', 'xmlEditRp/qtiCreator/plugins/panel/xmlResponseProcessing', 'panel');
             $this->setVersion('0.2.0');
         }
 
-        $this->skip('0.2.0', '1.0.0');
+        $this->skip('0.2.0', '1.0.1');
     }
-
-
 }

--- a/views/build/grunt/sass.js
+++ b/views/build/grunt/sass.js
@@ -1,4 +1,5 @@
-module.exports = function(grunt) {
+module.exports = function (grunt) {
+    'use strict';
 
     var sass    = grunt.config('sass') || {};
     var watch   = grunt.config('watch') || {};
@@ -7,9 +8,7 @@ module.exports = function(grunt) {
 
     //override load path
     sass.xmleditrp = {
-        options : {
-            loadPath : ['../scss/', root + 'scss/inc']
-        },
+        options : {},
         files : {}
     };
 

--- a/views/css/editor.css
+++ b/views/css/editor.css
@@ -1,2 +1,3 @@
 .custom-rp-editor-container h2{margin-top:0}.custom-rp-editor-container .tao-xml-editor.custom-rp-editor{border:1px solid #ddd;margin-bottom:20px}.custom-rp-editor-container .feedback-warning h3{margin-top:0}.custom-rp-editor-container .feedback-warning ul{padding:0}
+
 /*# sourceMappingURL=editor.css.map */

--- a/views/css/editor.css.map
+++ b/views/css/editor.css.map
@@ -1,7 +1,14 @@
 {
-"version": 3,
-"mappings": "AAII,8BAAG,CACC,UAAU,CAAC,CAAC,CAEhB,4DAAgC,CAC5B,MAAM,CAAG,cAAiC,CAC1C,aAAa,CAAG,IAAI,CAGpB,gDAAG,CACC,UAAU,CAAC,CAAC,CAEhB,gDAAG,CACC,OAAO,CAAC,CAAC",
-"sources": ["../scss/editor.scss"],
-"names": [],
-"file": "editor.css"
+	"version": 3,
+	"file": "editor.css",
+	"sources": [
+		"../scss/editor.scss",
+		"../../../tao/views/scss/inc/_bootstrap.scss",
+		"../../../tao/views/scss/inc/_variables.scss",
+		"../../../tao/views/scss/inc/_functions.scss",
+		"../../../tao/views/scss/inc/_colors.scss",
+		"../../../tao/views/scss/inc/fonts/_tao-icon-vars.scss"
+	],
+	"names": [],
+	"mappings": "AAGA,AACI,2BADuB,CACvB,EAAE,AAAC,CACC,UAAU,CAAC,CAAC,CACf,AAHL,AAII,2BAJuB,CAIvB,eAAe,AAAA,iBAAiB,AAAA,CAC5B,MAAM,CAAG,GAAG,CAAC,KAAK,CIiBD,IAAI,CJhBrB,aAAa,CAAG,IACpB,CAAE,AAPN,AASQ,2BATmB,CAQvB,iBAAiB,CACb,EAAE,AAAC,CACC,UAAU,CAAC,CAAC,CACf,AAXT,AAYQ,2BAZmB,CAQvB,iBAAiB,CAIb,EAAE,AAAC,CACC,OAAO,CAAC,CAAC,CACZ"
 }


### PR DESCRIPTION
Task - Tao
Jira: https://oat-sa.atlassian.net/browse/TAO-4692

Companion (but does not require):
- https://github.com/oat-sa/tao-core/pull/1410

This pr is meant to accompany the switch to libsass. Because the grunt sass script does not require a loadPath/includeFiles sass option, it is compatible with both ruby sass and libsass.