### PR TITLE
chore: update methods to lodash 4 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.22",
-        "oat-sa/tao-core": ">=50.24.6",
+        "oat-sa/tao-core": ">=54.0.0",
         "oat-sa/extension-tao-xmledit": ">=4.0.0"
     },
     "autoload": {

--- a/views/js/qtiCreator/plugins/panel/xmlResponseProcessing.js
+++ b/views/js/qtiCreator/plugins/panel/xmlResponseProcessing.js
@@ -102,7 +102,7 @@ define([
                     var r = variablesExist(item, xml);
                     var valid = !r.missing.length;
                     if(!valid){
-                        _.each(r.missing, function(m){
+                        _.forEach(r.missing, function(m){
                             messages.push(__('The variable %s does not exist.', m));
                         });
                     }
@@ -125,7 +125,7 @@ define([
                     }).done(function(r){
                         var valid = r.success;
                         if(!valid){
-                            _.each(r.errors, function(err){
+                            _.forEach(r.errors, function(err){
                                 messages.push(__('Invalid QTI xml %s', err.message || err));
                             });
                         }


### PR DESCRIPTION
Related: https://oat-sa.atlassian.net/browse/ADF-1579
Update lodash methods to version 4.
Documentation: https://github.com/lodash/lodash/wiki/Migrating